### PR TITLE
board: scobc-a1: add automatic power cycle after flashing

### DIFF
--- a/boards/sc/scobc_a1/board.cmake
+++ b/boards/sc/scobc_a1/board.cmake
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(openocd "--config=${BOARD_DIR}/support/scobc-a1.cfg")
+board_runner_args(openocd --cmd-post-verify "trigger_board_power_cycle")
 set(OPENOCD "${WEST_TOPDIR}/modules/tools/openocd/bin/openocd" CACHE FILEPATH "" FORCE)
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/sc/scobc_a1/support/scobc-a1.cfg
+++ b/boards/sc/scobc_a1/support/scobc-a1.cfg
@@ -52,3 +52,14 @@ flash bank sc_flash scqspi 0x0000000 0 0 0 $_CHIPNAME.cpu 0x01A00000 0
 if {![using_hla]} {
    cortex_m reset_config sysresetreq
 }
+
+# Trigger a board power cycle by sending a request to the TRCH.
+proc trigger_board_power_cycle { } {
+    set POWER_CYCLE_REG 0x4F000020
+    set POWER_CYCLE_REQ 0x5A5A0001
+
+    echo "Requesting board power cycle via TRCH..."
+    mww $POWER_CYCLE_REG $POWER_CYCLE_REQ
+
+    shutdown
+}


### PR DESCRIPTION
Add `trigger_board_power_cycle` procedure in OpenOCD config to request a power cycle via the TRCH power cycle register (0x4F000020) after programming.

This ensures the bootloader reloads the newly flashed application into RAM.

The procedure ends with an explicit `shutdown` to avoid the mandatory `reset run` issued by Zephyr’s OpenOCD runner after the `cmd-post-verify` hook. Without this, OpenOCD would attempt to reset a disconnected board during reboot, which leads to errors.

The function is hooked as `--cmd-post-verify` in the board’s `.board.cmake`, so it runs automatically after `west flash` but not during `west debug`.